### PR TITLE
Update to atlassian scanner v2+ and compatibility with bitbucket 5.14+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.facheris.bitbucket.plugins</groupId>
     <artifactId>linked-pull-requests</artifactId>
-    <version>0.2</version>
+    <version>0.3</version>
     <organization>
         <name>Patrick Facheris</name>
         <url>http://facheris.me/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>com.atlassian.plugins</groupId>
             <artifactId>atlassian-plugins-webfragment</artifactId>
-            <version>3.0.9</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -71,13 +70,7 @@
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugin</groupId>
-            <artifactId>atlassian-spring-scanner-runtime</artifactId>
-            <version>${atlassian.spring.scanner.version}</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -112,7 +105,6 @@
         <dependency>
             <groupId>com.atlassian.plugins.rest</groupId>
             <artifactId>atlassian-rest-common</artifactId>
-            <version>1.0.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -130,8 +122,6 @@
                 <version>${amps.version}</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <enableQuickReload>true</enableQuickReload>
-                    <enableFastdev>false</enableFastdev>
                     <products>
                         <product>
                             <id>bitbucket</id>
@@ -143,7 +133,7 @@
                     <instructions>
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
                         <!-- Add package to export here -->
-                        <Export-Package>me.facheris.bitbucket.plugins,</Export-Package>
+                        <Export-Package>me.facheris.bitbucket.plugins.*,</Export-Package>
                         <!-- Add package import here -->
                         <Import-Package>org.springframework.osgi.*;resolution:="optional", org.eclipse.gemini.blueprint.*;resolution:="optional", *</Import-Package>
                         <!-- Ensure plugin is Spring powered -->
@@ -176,12 +166,15 @@
         </plugins>
     </build>
     <properties>
-        <bitbucket.version>4.11.0</bitbucket.version>
-        <bitbucket.data.version>4.11.0</bitbucket.data.version>
-        <amps.version>6.2.11</amps.version>
+        <bitbucket.version>5.14.0</bitbucket.version>
+        <bitbucket.data.version>5.14.0</bitbucket.data.version>
+        <amps.version>6.3.21</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
-        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
+        <atlassian.spring.scanner.version>2.1.3</atlassian.spring.scanner.version>
         <!-- This key is used to keep the consistency between the key in atlassian-plugin.xml and the key to generate bundle. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 </project>

--- a/src/main/java/me/facheris/bitbucket/plugins/models/LinkedPullRequest.java
+++ b/src/main/java/me/facheris/bitbucket/plugins/models/LinkedPullRequest.java
@@ -1,22 +1,17 @@
 package me.facheris.bitbucket.plugins.models;
 
+import com.atlassian.bitbucket.pull.PullRequest;
+import com.atlassian.bitbucket.pull.PullRequestService;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElementRef;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import com.atlassian.bitbucket.pull.PullRequest;
-import com.atlassian.bitbucket.pull.PullRequestService;
-
-import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
-import com.atlassian.sal.api.pluginsettings.PluginSettings;
-
-import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
-import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
-
-import javax.xml.bind.annotation.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /*
  * Represents all links to/from a specific pull request.

--- a/src/main/java/me/facheris/bitbucket/plugins/models/PullRequestLink.java
+++ b/src/main/java/me/facheris/bitbucket/plugins/models/PullRequestLink.java
@@ -1,15 +1,14 @@
 package me.facheris.bitbucket.plugins.models;
 
-import java.util.UUID;
-
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestService;
-import com.atlassian.bitbucket.pull.PullRequestState;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElementRef;
+import java.util.UUID;
 
 /*
  * Represents a unique link from an origin PullRequest to a target PullRequest

--- a/src/main/java/me/facheris/bitbucket/plugins/rest/LinkedPullRequestsRestResource.java
+++ b/src/main/java/me/facheris/bitbucket/plugins/rest/LinkedPullRequestsRestResource.java
@@ -1,28 +1,16 @@
 package me.facheris.bitbucket.plugins.rest;
 
-import me.facheris.bitbucket.plugins.models.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.net.URI;
-
-import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
-import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
-import org.springframework.web.bind.annotation.RequestBody;
-
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestService;
-import com.atlassian.bitbucket.repository.RepositoryService;
 import com.atlassian.bitbucket.repository.Repository;
-
+import com.atlassian.bitbucket.repository.RepositoryService;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import me.facheris.bitbucket.plugins.models.LinkedPullRequest;
+import me.facheris.bitbucket.plugins.models.PullRequestLink;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -33,9 +21,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.UUID;
 
 
-@Scanned
+@Component
 @Path("/projects/{project}/repos/{slug}/pull-requests/{pullRequestId}")
 public class LinkedPullRequestsRestResource
 {

--- a/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/src/main/resources/META-INF/spring/plugin-context.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner"
+       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner/2"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.atlassian.com/schema/atlassian-scanner
-        http://www.atlassian.com/schema/atlassian-scanner/atlassian-scanner.xsd">
+        http://www.atlassian.com/schema/atlassian-scanner/2
+        http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
     <atlassian-scanner:scan-indexes/>
 </beans>


### PR DESCRIPTION
It seems this plugin's maximum bitbucket version is currently 5.13. This should allow for 5.14+ installations.